### PR TITLE
Fix attribute selection language and attribute sync bug

### DIFF
--- a/src/Hyyan/WPI/Product/Product.php
+++ b/src/Hyyan/WPI/Product/Product.php
@@ -38,6 +38,9 @@ class Product
         // sync post parent (good for grouped products)
         add_filter('admin_init', array($this, 'syncPostParent'));
 
+        // get attributes in current language
+        add_filter('woocommerce_product_attribute_terms', array($this, 'getProductAttributesInLanguage'));
+
         new Meta();
         new Variable();
         new Duplicator();
@@ -81,5 +84,29 @@ class Product
             update_option('polylang', $options);
         }
     }
+
+    /**
+     * Get product attributes in right language
+     *
+     * @param array $args array of arguments for get_terms function in WooCommerce attributes html markup
+     *
+     * @return array
+     */
+    public function getProductAttributesInLanguage($args)
+    {
+        $lang = '';
+        global $post;
+        if(isset($_GET['new_lang'])) {
+            $lang = esc_attr($_GET['new_lang']);
+        } elseif(!empty($post)) {
+            $lang = pll_get_post_language($post->ID);
+        } else {
+            $lang = PLL()->pref_lang;
+        }
+        $args['lang'] = $lang;
+        return $args;
+    }
+
+
 
 }


### PR DESCRIPTION
The fix for the issue [#26 in Hyyan repository](https://github.com/hyyan/woo-poly-integration/issues/26). Also makes selectable attributes be in the same language as the product when creating a new product.

In your fork, it's related to #2 and #16.
